### PR TITLE
Print version info to Stdout instead of Stderr

### DIFF
--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -40,7 +40,7 @@ func init() {
 	flag.Parse()
 
 	if printVersion {
-		fmt.Fprintf(os.Stderr, "gost %s (%s %s/%s)\n",
+		fmt.Fprintf(os.Stdout, "gost %s (%s %s/%s)\n",
 			gost.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Otherwise we can't get the right version information by this:
```shell
gost -V | cut -d' ' -f2
```